### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/FinFam/src/create_test_users.ts
+++ b/FinFam/src/create_test_users.ts
@@ -11,7 +11,7 @@ async function createTestUsers() {
     senha: adminPassword,
     funcao: 'administrador',
   };
-  console.log('Usuário Administrador:', JSON.stringify(adminUser));
+  console.log('Usuário Administrador:', JSON.stringify({ nome: adminUser.nome, email: adminUser.email, funcao: adminUser.funcao }));
 
   // Usuário familiar
   const familiarPassword = await bcrypt.hash('familiar123', saltRounds);
@@ -21,7 +21,7 @@ async function createTestUsers() {
     senha: familiarPassword,
     funcao: 'familiar',
   };
-  console.log('Usuário Familiar:', JSON.stringify(familiarUser));
+  console.log('Usuário Familiar:', JSON.stringify({ nome: familiarUser.nome, email: familiarUser.email, funcao: familiarUser.funcao }));
 }
 
 createTestUsers();


### PR DESCRIPTION
Potential fix for [https://github.com/natan23f3/Teste2/security/code-scanning/3](https://github.com/natan23f3/Teste2/security/code-scanning/3)

To fix the issue, we should avoid logging sensitive information such as passwords, even in hashed form. Instead, we can log non-sensitive details about the user, such as their name and role, which are sufficient for debugging purposes. This ensures that no sensitive data is exposed in the logs.

The fix involves modifying the `console.log` statements to exclude the `senha` (password) field from the logged output. This can be achieved by creating a sanitized version of the user object that omits sensitive fields before logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
