### PR TITLE
Potential fix for code scanning alert no. 1: Missing CSRF middleware

### DIFF
--- a/FinFam/package.json
+++ b/FinFam/package.json
@@ -54,7 +54,8 @@
     "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.3.6",
     "winston": "^3.11.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",

--- a/FinFam/server/server.ts
+++ b/FinFam/server/server.ts
@@ -6,6 +6,7 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import passport from 'passport';
 import session from 'express-session';
+import lusca from 'lusca';
 import * as dotenv from 'dotenv';
 import './config/passportConfig'; // Importa a configuração do Passport
 import flash from 'connect-flash';
@@ -121,6 +122,9 @@ app.use(session({
     sameSite: 'strict' // Previne ataques CSRF
   }
 }));
+
+// Middleware de proteção contra CSRF
+app.use(lusca.csrf());
 
 // Configuração do Passport
 app.use(passport.initialize());


### PR DESCRIPTION
Potential fix for [https://github.com/natan23f3/Teste2/security/code-scanning/1](https://github.com/natan23f3/Teste2/security/code-scanning/1)

To fix the issue, we will add CSRF protection middleware to the application. The `lusca` library is a well-known middleware package for CSRF protection in Express applications. We will:
1. Install the `lusca` package if it is not already installed.
2. Import the `lusca` library and configure its CSRF middleware.
3. Add the CSRF middleware to the application after the `session` middleware to ensure that it can access the session data.
4. Ensure that the CSRF token is included in responses where necessary (e.g., in forms or headers) so that clients can include it in subsequent requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
